### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout-xxhdpi/fragment_enter_pin.xml
+++ b/app/src/main/res/layout-xxhdpi/fragment_enter_pin.xml
@@ -183,7 +183,7 @@
             android:layout_marginRight="60dp"
             android:background="@drawable/inactive_button"
             android:text="@string/show_mnemonics_button"
-            android:textColor="@color/white" />
+            android:textColor="#3D3D3D" />
 
         />
 

--- a/app/src/main/res/layout/fragment_enter_pin.xml
+++ b/app/src/main/res/layout/fragment_enter_pin.xml
@@ -182,7 +182,7 @@
             android:layout_marginRight="60dp"
             android:background="@drawable/inactive_button"
             android:text="@string/show_mnemonics_button"
-            android:textColor="@color/white" />
+            android:textColor="#3D3D3D" />
 
         />
 


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#A8A8A8') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#3D3D3D') are as follows:
![image](https://user-images.githubusercontent.com/101503193/185456380-de4eb24d-a2ba-484f-8bea-e210146584a2.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.